### PR TITLE
Reduce memory usage when generating thumbnails

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -16,6 +16,7 @@ class Image < ActiveRecord::Base
   has_attached_file :file,
     :styles => { :thumb => '200x200#' },
     :convert_options => { :thumb => '-quality 75 -strip' },
+    :source_file_options => { :all => '-limit memory 64MiB -limit map 64MiB' },
     :path => 'public/:style/:basename:extension',
     :url => '/:style/:basename:extension'
 


### PR DESCRIPTION
Closes #1.

Large GIFs cause convert to use up more memory than is available, causing the process to get killed and image upload to ultimately fail. Well spotted @mmolina.
